### PR TITLE
增加对.dll缺失的提示 & 修正 README 拼写错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,6 @@
   第二种方法: 下载或自行构建 GitHubDesktop2Chinese.exe  和 localization.json  放在同一个文件夹。运行程序即可  
   GitHubDesktop每次版本更新都需要运行一次此程序才能完成汉化
 
-> [!tip]
-> 如果打开 GitHubDesktop2Chinese.exe 时发现缺失 `MSVCP140_ATOMIC_WAIT.dll`，可以尝试下载微软运行库 [Microsoft Visual C++ Redistributable 14.42.34433.0](https://learn.microsoft.com/zh-cn/cpp/windows/latest-supported-vc-redist?view=msvc-170)。找到 `最新的 Microsoft Visual C++ 可再发行程序包版本`，选择与你相应的操作系统的版本进行下载（比如64位的电脑选择 `vc_redist.x64.exe	`，32位的电脑选择 `vc_redist.x86.exe`），安装即可。
-
 ## 🎏怎么编译源代码
 
 > 下载克隆项目 本地使用VS2022 使用CMAKE打开，即可构建
@@ -52,8 +49,10 @@
 ## 🧭其他
 
 > 如果报错提示找不到openssl 的dll文件，请更新到[最新版](https://github.com/cngege/GitHubDesktop2Chinese/releases)   
-  如果你有任何建议可以提issus.
+  如果你有任何建议可以提issues.
 
+> [!tip]
+> 如果打开 GitHubDesktop2Chinese.exe 时发现缺失 `MSVCP140_ATOMIC_WAIT.dll`，可以尝试下载微软运行库 [Microsoft Visual C++ Redistributable 14.42.34433.0](https://learn.microsoft.com/zh-cn/cpp/windows/latest-supported-vc-redist?view=msvc-170)。找到 `最新的 Microsoft Visual C++ 可再发行程序包版本`，选择与你相应的操作系统的版本进行下载（比如64位的电脑选择 `vc_redist.x64.exe	`，32位的电脑选择 `vc_redist.x86.exe`），安装即可。
 
 ## 🍬第三方库  
 **感谢以下诸位提供的优质的开源项目**  

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@
   第二种方法: 下载或自行构建 GitHubDesktop2Chinese.exe  和 localization.json  放在同一个文件夹。运行程序即可  
   GitHubDesktop每次版本更新都需要运行一次此程序才能完成汉化
 
+> [!tip]
+> 如果打开 GitHubDesktop2Chinese.exe 时发现缺失 `MSVCP140_ATOMIC_WAIT.dll`，可以尝试下载微软运行库 [Microsoft Visual C++ Redistributable 14.42.34433.0](https://learn.microsoft.com/zh-cn/cpp/windows/latest-supported-vc-redist?view=msvc-170)。找到 `最新的 Microsoft Visual C++ 可再发行程序包版本`，选择与你相应的操作系统的版本进行下载（比如64位的电脑选择 `vc_redist.x64.exe	`，32位的电脑选择 `vc_redist.x86.exe`），安装即可。
+
 ## 🎏怎么编译源代码
 
 > 下载克隆项目 本地使用VS2022 使用CMAKE打开，即可构建


### PR DESCRIPTION
几天前，我从 Windows 11 重装回 Windows 10。打开 `GitHubDesktop2Chinese.exe` 发现如图所示的弹窗。
![406347932-675aa83b-543c-4d55-aa51-093288520fe1](https://github.com/user-attachments/assets/5845ed10-7db1-4108-91c9-095605cacaff)

翻遍 [Google](https://www.google.com/search?q=microsoft+visual+c%2B%2B+redistributable+msvcp140+dll&oq=Microsoft+Visual+C%2B%2B+Redistributable+MSV&gs_lcrp=EgZjaHJvbWUqBwgBEAAYgAQyBggAEEUYOTIHCAEQABiABDIICAIQABgKGB4yCAgDEAAYChgeMggIBBAAGAgYHjIKCAUQABiABBiiBDIKCAYQABiABBiiBDIGCAcQRRg80gEINzQwMmowajSoAgCwAgE&sourceid=chrome&ie=UTF-8)，发现**应该**是安装 `最新的 Microsoft Visual C++ 可再发行程序包版本` 就能解决这个问题。

### 如何得出猜想？
由于是几天前安装的（后来发现是22号），我不记得从微软的哪里下载的了（后来看 IDM 得知），安装好这个运行库之后我就没动有汉化工具。

![image](https://github.com/user-attachments/assets/e9bc6ac1-351a-40f1-b323-53a1be891f24)
![image](https://github.com/user-attachments/assets/f7aa2265-33eb-4656-a540-0869521377fb)
![image](https://github.com/user-attachments/assets/0a08502b-a0e6-4d24-a993-2337aeae814b)

最近发现这个汉化工具能打开了，应该是这个运行库给的 `.dll`。所以在这里分享一下 TIP。

我没装有 Windows 沙盒，不知道是不是这个运行库给予的dll文件。如果有能力的话，建议试一下，看看我的猜想是否正确。这个pr我先设为草案，等有明确的实验结果再打开。

# 其他
感谢 @xiaoshu312 在 #7 指出的问题，现已在本 pr 修复。